### PR TITLE
Fix FPS drop caused by SSBO sync when VSync is off

### DIFF
--- a/src/main/java/dev/nonamecrackers2/simpleclouds/client/mesh/generator/CloudMeshGenerator.java
+++ b/src/main/java/dev/nonamecrackers2/simpleclouds/client/mesh/generator/CloudMeshGenerator.java
@@ -802,6 +802,12 @@ public abstract class CloudMeshGenerator
 	
 	protected void onOffGen()
 	{
+		//Fix fps drop when not using V-Sync in fullscreen BY Gaboouu
+        Minecraft mc = Minecraft.getInstance();
+        if (mc == null || mc.options == null || !mc.options.enableVsync().get())
+            return;
+        if (!mc.getWindow().isFullscreen())
+            return;
 		//We read these SSBOs here to avoid weird frame spikes when in fullscreen V-Sync, not sure why it happens
 		if (!this.useFixedMeshDataSectionSize)
 			this.shader.getShaderStorageBuffer(TOTAL_SIDES_NAME).readWriteData(b -> {}, 4);
@@ -1147,3 +1153,4 @@ public abstract class CloudMeshGenerator
 		}
 	}
 }
+


### PR DESCRIPTION
This change prevents unnecessary SSBO readWriteData calls when VSync is disabled.

The previous logic forced buffer mapping every update to mitigate fullscreen VSync spikes, but this caused heavy GPU synchronization and major FPS loss when VSync was off.

The SSBO warmup logic is now gated behind the VSync setting so it only runs in the scenario it was originally meant to address.

This removes constant render thread stalls and restores stable framerate while preserving the original VSync behavior.